### PR TITLE
Fast-forward upstream changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @cpubot @muursh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cpubot @muursh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,49 +1,65 @@
-name: ci
+name: Continuous Integration
 
 on:
   push:
     branches:
       - main
   pull_request:
+    branches:
+      - "**"
+  workflow_dispatch:
+    branches:
+      - "**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+    CARGO_TERM_COLOR: always
 
 jobs:
-  check:
+  test:
+    name: Run tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
-      - name: Remove Pre-installed Rust
-        run: |
-          rustup toolchain remove stable
-          rm -f /home/runner/.cargo/bin/rust-analyzer
-          rm -f /home/runner/.cargo/bin/rustfmt
-          rm -f /home/runner/.cargo/bin/cargo-fmt
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
 
-      - name: Install Rust Nightly
-        run: |
-          rustup update nightly
-          rustup default nightly
-          rustup component add rustfmt --toolchain nightly
-          rustup component add clippy --toolchain nightly
-
-      - name: Get Rust Version
-        run: rustc --version > rust-version.txt
-
-      - name: Cache Cargo Registry and Build Outputs
-        uses: actions/cache@v2
+      - name: Set up rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-rust-${{ hashFiles('rust-version.txt', '**/Cargo.lock') }}
+            cache-on-failure: true
+
+      - name: Test
+        run: cargo test
+
+  lints:
+    name: Formatting and Clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+            components: rustfmt, clippy
+
+      - name: Set up rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+            cache-on-failure: true
+
+      - name: Run cargo fmt
+        run: cargo fmt --all --check
 
       - name: Run cargo clippy
-        run: cargo +nightly clippy -- -D warnings
-
-      - name: Run cargo fmt --check
-        run: cargo +nightly fmt --all -- --check
-
-      - name: Run cargo test
-        run: cargo test
+        run: cargo clippy --all-targets -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 /target
-/prover_state
+
+# Default extension for generated block proofs
 *.zkproof
-prover_state_*
-verifier_state_*
+
+# Folder containing all the locally generated circuit data
+circuits/
+
+# Folders containing logs from the utility scripts in tools/
+debug/
+proofs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -600,11 +600,13 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 name = "common"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
+ "evm_arithmetization",
  "plonky2",
- "plonky2_evm",
- "plonky_block_proof_gen",
+ "proof_gen",
  "thiserror",
+ "trace_decoder",
  "tracing",
 ]
 
@@ -619,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "const-random"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11df32a13d7892ec42d51d3d175faba5211ffe13ed25d4fb348ac9e9ce835593"
+checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
 dependencies = [
  "const-random-macro",
 ]
@@ -811,7 +813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -882,18 +884,6 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "enum-as-inner"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
@@ -945,25 +935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eth_trie_utils"
-version = "0.6.0"
-source = "git+https://github.com/0xPolygonZero/eth_trie_utils.git?rev=7fc3c3f54b3cec9c6fc5ffc5230910bd1cb77f76#7fc3c3f54b3cec9c6fc5ffc5230910bd1cb77f76"
-dependencies = [
- "bytes",
- "enum-as-inner 0.5.1",
- "ethereum-types",
- "hex",
- "keccak-hash 0.10.0",
- "log",
- "num-traits",
- "parking_lot",
- "rlp",
- "serde",
- "thiserror",
- "uint",
-]
-
-[[package]]
 name = "ethbloom"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +966,42 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "evm_arithmetization"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2af65f5b147f04c94df5df5e21ff9d1632fd357511e183d5e04de059d6fa93"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "env_logger",
+ "ethereum-types",
+ "hashbrown 0.14.3",
+ "hex-literal",
+ "itertools",
+ "jemallocator",
+ "keccak-hash 0.10.0",
+ "log",
+ "mpt_trie",
+ "num",
+ "num-bigint",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "plonky2",
+ "plonky2_maybe_rayon",
+ "plonky2_util",
+ "rand",
+ "rand_chacha",
+ "rlp",
+ "rlp-derive",
+ "serde",
+ "serde_json",
+ "starky",
+ "static_assertions",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "executor-trait"
@@ -1209,9 +1216,9 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1219,7 +1226,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.0.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -1249,9 +1256,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -1479,7 +1486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "serde",
 ]
 
@@ -1634,8 +1641,7 @@ dependencies = [
  "ethereum-types",
  "ops",
  "paladin-core",
- "plonky2_evm",
- "plonky_block_proof_gen",
+ "proof_gen",
  "prover",
  "rpc",
  "serde",
@@ -1754,13 +1760,34 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "mpt_trie"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf6d77f630021e46e127abfa047aebfba78bf207ed3dfd1c4f9e2370f9b60cd"
+dependencies = [
+ "bytes",
+ "enum-as-inner",
+ "ethereum-types",
+ "hex",
+ "keccak-hash 0.10.0",
+ "log",
+ "num",
+ "num-traits",
+ "parking_lot",
+ "rlp",
+ "serde",
+ "thiserror",
+ "uint",
 ]
 
 [[package]]
@@ -1897,10 +1924,11 @@ name = "ops"
 version = "0.1.0"
 dependencies = [
  "common",
+ "evm_arithmetization",
  "paladin-core",
- "plonky_block_proof_gen",
- "protocol_decoder",
+ "proof_gen",
  "serde",
+ "trace_decoder",
 ]
 
 [[package]]
@@ -1928,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "paladin-core"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c10eebceee2898070e490a57ada2bd3810c236a6d80aadccab4d70ef27c7aa34"
+checksum = "5af1955eaab1506a43d046628c218b7b3915539554838feb85ed31f54aace2f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2138,13 +2166,14 @@ dependencies = [
 
 [[package]]
 name = "plonky2"
-version = "0.1.4"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=265d46a96ecfec49a32973f66f8aa811586c5d4a#265d46a96ecfec49a32973f66f8aa811586c5d4a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25deb9a4b9c2014c2f99cd36078f30e453d188d0ca8dd4c5ffd1d494b661ac1"
 dependencies = [
  "ahash",
  "anyhow",
  "getrandom",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
  "itertools",
  "keccak-hash 0.8.0",
  "log",
@@ -2155,49 +2184,16 @@ dependencies = [
  "rand",
  "rand_chacha",
  "serde",
- "serde_json",
  "static_assertions",
  "unroll",
-]
-
-[[package]]
-name = "plonky2_evm"
-version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=265d46a96ecfec49a32973f66f8aa811586c5d4a#265d46a96ecfec49a32973f66f8aa811586c5d4a"
-dependencies = [
- "anyhow",
- "bytes",
- "env_logger",
- "eth_trie_utils",
- "ethereum-types",
- "hashbrown 0.14.2",
- "hex-literal",
- "itertools",
- "jemallocator",
- "keccak-hash 0.10.0",
- "log",
- "num",
- "num-bigint",
- "once_cell",
- "pest",
- "pest_derive",
- "plonky2",
- "plonky2_maybe_rayon",
- "plonky2_util",
- "rand",
- "rand_chacha",
- "rlp",
- "rlp-derive",
- "serde",
- "serde_json",
- "static_assertions",
- "tiny-keccak",
+ "web-time",
 ]
 
 [[package]]
 name = "plonky2_field"
-version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=265d46a96ecfec49a32973f66f8aa811586c5d4a#265d46a96ecfec49a32973f66f8aa811586c5d4a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465a741ba134485af571152aab5086457a470aa8893391186cf78dd389694440"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2211,30 +2207,18 @@ dependencies = [
 
 [[package]]
 name = "plonky2_maybe_rayon"
-version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=265d46a96ecfec49a32973f66f8aa811586c5d4a#265d46a96ecfec49a32973f66f8aa811586c5d4a"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ff44a90aaca13e10e7ddf8fab815ba1b404c3f7c3ca82aaf11c46beabaa923"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "plonky2_util"
-version = "0.1.1"
-source = "git+https://github.com/0xPolygonZero/plonky2.git?rev=265d46a96ecfec49a32973f66f8aa811586c5d4a#265d46a96ecfec49a32973f66f8aa811586c5d4a"
-
-[[package]]
-name = "plonky_block_proof_gen"
-version = "0.1.0"
-source = "git+https://github.com/0xPolygonZero/proof-protocol-decoder.git?rev=604e956f674dc1ea7d6c5e71c594b328e7b25399#604e956f674dc1ea7d6c5e71c594b328e7b25399"
-dependencies = [
- "ethereum-types",
- "log",
- "paste",
- "plonky2",
- "plonky2_evm",
- "protocol_decoder",
- "serde",
-]
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16136f5f3019c1e83035af76cccddd56d789a5e2933306270185c3f99f12259"
 
 [[package]]
 name = "polling"
@@ -2319,27 +2303,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "protocol_decoder"
-version = "0.1.0"
-source = "git+https://github.com/0xPolygonZero/proof-protocol-decoder.git?rev=604e956f674dc1ea7d6c5e71c594b328e7b25399#604e956f674dc1ea7d6c5e71c594b328e7b25399"
+name = "proof_gen"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "657003bc7dcee8b7c487807b8c9e6bf8aef8413f80501948a948b40c885ab7e7"
 dependencies = [
- "bytes",
- "ciborium",
- "ciborium-io",
- "enum-as-inner 0.6.0",
- "enumn",
- "eth_trie_utils",
  "ethereum-types",
- "hex",
- "hex-literal",
- "keccak-hash 0.10.0",
+ "evm_arithmetization",
  "log",
- "plonky2_evm",
- "rlp",
- "rlp-derive",
+ "paste",
+ "plonky2",
  "serde",
- "serde_with",
- "thiserror",
+ "trace_decoder",
 ]
 
 [[package]]
@@ -2348,11 +2323,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ethereum-types",
+ "futures",
  "ops",
  "paladin-core",
- "plonky_block_proof_gen",
- "protocol_decoder",
+ "proof_gen",
  "serde",
+ "trace_decoder",
  "tracing",
 ]
 
@@ -2577,11 +2553,10 @@ dependencies = [
  "clap",
  "common",
  "ethereum-types",
+ "evm_arithmetization",
  "futures",
  "hex",
  "hex-literal",
- "plonky2_evm",
- "protocol_decoder",
  "prover",
  "reqwest",
  "serde",
@@ -2589,6 +2564,7 @@ dependencies = [
  "serde_path_to_error",
  "thiserror",
  "tokio",
+ "trace_decoder",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2764,18 +2740,18 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2933,6 +2909,23 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "starky"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e0a1eec739c7a67cb1c6f916c0b7bf2d281cf2edb35d3db5caa6989090133e"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "hashbrown 0.14.3",
+ "itertools",
+ "log",
+ "num-bigint",
+ "plonky2",
+ "plonky2_maybe_rayon",
+ "plonky2_util",
+]
 
 [[package]]
 name = "static_assertions"
@@ -3247,6 +3240,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
+name = "trace_decoder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f08487265f29176ad03c894b1c1cf8da5adf9d82fc151b3191eb7f55350b5c58"
+dependencies = [
+ "bytes",
+ "ciborium",
+ "ciborium-io",
+ "enum-as-inner",
+ "enumn",
+ "ethereum-types",
+ "evm_arithmetization",
+ "hex",
+ "hex-literal",
+ "keccak-hash 0.10.0",
+ "log",
+ "mpt_trie",
+ "rlp",
+ "rlp-derive",
+ "serde",
+ "serde_with",
+ "thiserror",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,7 +3435,7 @@ dependencies = [
  "clap",
  "common",
  "dotenvy",
- "plonky_block_proof_gen",
+ "proof_gen",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -3523,6 +3541,16 @@ name = "web-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3691,18 +3719,18 @@ checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.15"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ba595b9f2772fbee2312de30eeb80ec773b4cb2f1e8098db024afadda6c06f"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.15"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772666c41fb6dceaf520b564b962d738a8e1a83b41bd48945f50837aed78bb1d"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["leader", "worker", "common", "ops", "verifier", "rpc", "prover"]
 resolver = "2"
 
 [workspace.dependencies]
-paladin-core = "0.4.1"
+paladin-core = "0.4.2"
 anyhow = { version = "1.0.75", features = ["backtrace"] }
 dotenvy = "0.15.7"
 tracing = "0.1"
@@ -11,14 +11,17 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4.4.6", features = ["derive", "env"] }
 tokio = { version = "1.33.0", features = ["full"] }
 serde = "1.0.183"
-plonky_block_proof_gen = { git = "https://github.com/0xPolygonZero/proof-protocol-decoder.git", rev = "604e956f674dc1ea7d6c5e71c594b328e7b25399" }
-protocol_decoder = { git = "https://github.com/0xPolygonZero/proof-protocol-decoder.git", rev = "604e956f674dc1ea7d6c5e71c594b328e7b25399" }
-plonky2_evm = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "265d46a96ecfec49a32973f66f8aa811586c5d4a" }
-plonky2 = { git = "https://github.com/0xPolygonZero/plonky2.git", rev = "265d46a96ecfec49a32973f66f8aa811586c5d4a" }
 serde_path_to_error = "0.1.14"
 serde_json = "1.0.108"
 ethereum-types = "0.14.1"
 thiserror = "1.0.50"
+futures = "0.3.29"
+
+# zk-evm dependencies
+plonky2 = "0.2.0"
+evm_arithmetization = "0.1.1"
+trace_decoder = "0.1.1"
+proof_gen = "0.1.1"
 
 [workspace.package]
 edition = "2021"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,7 +11,9 @@ categories.workspace = true
 [dependencies]
 thiserror = { workspace = true }
 tracing = { workspace = true }
-plonky_block_proof_gen = { workspace = true }
+proof_gen = { workspace = true }
 plonky2 = { workspace = true }
-plonky2_evm = { workspace = true }
+evm_arithmetization = { workspace = true }
 clap = { workspace = true }
+anyhow = { workspace = true }
+trace_decoder = { workspace = true }

--- a/common/src/prover_state/circuit.rs
+++ b/common/src/prover_state/circuit.rs
@@ -5,13 +5,15 @@ use std::{
     str::FromStr,
 };
 
-use plonky2_evm::{all_stark::AllStark, config::StarkConfig};
-use plonky_block_proof_gen::types::AllRecursiveCircuits;
+use evm_arithmetization::{AllStark, StarkConfig};
+use proof_gen::types::AllRecursiveCircuits;
 
 use crate::parsing::{parse_range, RangeParseError};
 
 /// Number of tables defined in plonky2.
-const NUM_TABLES: usize = 7;
+///
+/// TODO: This should be made public in the evm_arithmetization crate.
+pub(crate) const NUM_TABLES: usize = 7;
 
 /// New type wrapper for [`Range`] that implements [`FromStr`] and [`Display`].
 ///
@@ -111,6 +113,19 @@ impl Circuit {
             Circuit::Memory => "memory",
         }
     }
+
+    /// Get the circuit name as a short str literal.
+    pub const fn as_short_str(&self) -> &'static str {
+        match self {
+            Circuit::Arithmetic => "a",
+            Circuit::BytePacking => "bp",
+            Circuit::Cpu => "c",
+            Circuit::Keccak => "k",
+            Circuit::KeccakSponge => "ks",
+            Circuit::Logic => "l",
+            Circuit::Memory => "m",
+        }
+    }
 }
 
 impl From<usize> for Circuit {
@@ -128,9 +143,25 @@ impl From<usize> for Circuit {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CircuitConfig {
     circuits: [Range<usize>; NUM_TABLES],
+}
+
+impl std::ops::Index<usize> for CircuitConfig {
+    type Output = Range<usize>;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.circuits[index]
+    }
+}
+
+impl std::ops::Index<Circuit> for CircuitConfig {
+    type Output = Range<usize>;
+
+    fn index(&self, index: Circuit) -> &Self::Output {
+        &self.circuits[index as usize]
+    }
 }
 
 impl Default for CircuitConfig {
@@ -176,16 +207,8 @@ impl CircuitConfig {
     /// Get a unique string representation of the config.
     pub fn get_configuration_digest(&self) -> String {
         self.enumerate()
-            .map(|(circuit, range)| match circuit {
-                Circuit::Arithmetic => format!("a_{}-{}", range.start, range.end),
-                Circuit::BytePacking => format!("b_p_{}-{}", range.start, range.end),
-                Circuit::Cpu => format!("c_{}-{}", range.start, range.end),
-                Circuit::Keccak => format!("k_{}-{}", range.start, range.end),
-                Circuit::KeccakSponge => {
-                    format!("k_s_{}-{}", range.start, range.end)
-                }
-                Circuit::Logic => format!("l_{}-{}", range.start, range.end),
-                Circuit::Memory => format!("m_{}-{}", range.start, range.end),
+            .map(|(circuit, range)| {
+                format!("{}_{}-{}", circuit.as_short_str(), range.start, range.end)
             })
             .fold(String::new(), |mut acc, s| {
                 if !acc.is_empty() {

--- a/common/src/prover_state/mod.rs
+++ b/common/src/prover_state/mod.rs
@@ -2,22 +2,47 @@
 //!
 //! This module provides the following:
 //! - [`Circuit`] and [`CircuitConfig`] which can be used to dynamically
-//!   construct [`AllRecursiveCircuits`] from the specified circuit sizes.
+//!   construct [`evm_arithmetization::fixed_recursive_verifier::AllRecursiveCircuits`]
+//!   from the specified circuit sizes.
 //! - Command line arguments for constructing a [`CircuitConfig`].
 //!     - Provides default values for the circuit sizes.
 //!     - Allows the circuit sizes to be specified via environment variables.
-//! - Persistence utilities for saving and loading [`AllRecursiveCircuits`].
+//! - Persistence utilities for saving and loading
+//!   [`evm_arithmetization::fixed_recursive_verifier::AllRecursiveCircuits`].
 //! - Global prover state management via the [`P_STATE`] static and the
 //!   [`set_prover_state_from_config`] function.
 use std::{fmt::Display, sync::OnceLock};
 
 use clap::ValueEnum;
-use plonky_block_proof_gen::{prover_state::ProverState, VerifierState};
+use evm_arithmetization::{proof::AllProof, prover::prove, AllStark, StarkConfig};
+use plonky2::{
+    field::goldilocks_field::GoldilocksField, plonk::config::PoseidonGoldilocksConfig,
+    util::timing::TimingTree,
+};
+use proof_gen::{proof_types::GeneratedTxnProof, prover_state::ProverState, VerifierState};
+use trace_decoder::types::TxnProofGenIR;
 use tracing::info;
+
+use self::circuit::{CircuitConfig, NUM_TABLES};
+use crate::prover_state::persistence::{
+    BaseProverResource, DiskResource, MonolithicProverResource, RecursiveCircuitResource,
+    VerifierResource,
+};
 
 pub mod circuit;
 pub mod cli;
 pub mod persistence;
+
+pub(crate) type Config = PoseidonGoldilocksConfig;
+pub(crate) type Field = GoldilocksField;
+pub(crate) const SIZE: usize = 2;
+
+pub(crate) type RecursiveCircuitsForTableSize =
+    evm_arithmetization::fixed_recursive_verifier::RecursiveCircuitsForTableSize<
+        Field,
+        Config,
+        SIZE,
+    >;
 
 /// The global prover state.
 ///
@@ -28,107 +53,281 @@ pub mod persistence;
 /// - This scheme works for both a cluster and a single machine. In particular,
 ///   whether imported from a worker node or a thread in the leader node
 ///   (in-memory mode), the prover state is initialized only once.
-pub static P_STATE: OnceLock<ProverState> = OnceLock::new();
+static P_STATE: OnceLock<ProverState> = OnceLock::new();
 
-/// Specifies whether to persist the processed circuits.
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum CircuitPersistence {
-    /// Do not persist the processed circuits.
-    None,
-    /// Persist the processed circuits to disk.
-    Disk,
+/// The global prover state manager.
+///
+/// Unlike the prover state, the prover state manager houses configuration and
+/// persistence information. This allows it to differentiate between the
+/// different transaction proof generation strategies. As such, it is generally
+/// only necessary when generating transaction proofs.
+///
+/// It's specified as a `OnceLock` for the same reasons as the prover state.
+static MANAGER: OnceLock<ProverStateManager> = OnceLock::new();
+
+pub fn p_state() -> &'static ProverState {
+    P_STATE.get().expect("Prover state is not initialized")
 }
 
-impl Display for CircuitPersistence {
+pub fn p_manager() -> &'static ProverStateManager {
+    MANAGER
+        .get()
+        .expect("Prover state manager is not initialized")
+}
+
+/// Specifies how to load the table circuits.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum TableLoadStrategy {
+    #[default]
+    /// Load the circuit tables as needed for shrinking STARK proofs.
+    ///
+    /// - Generate a STARK proof.
+    /// - Compute the degree bits.
+    /// - Load the necessary table circuits.
+    OnDemand,
+    /// Load all the table circuits into a monolithic bundle.
+    Monolithic,
+}
+
+impl Display for TableLoadStrategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CircuitPersistence::None => write!(f, "none"),
-            CircuitPersistence::Disk => write!(f, "disk"),
+            TableLoadStrategy::OnDemand => write!(f, "on-demand"),
+            TableLoadStrategy::Monolithic => write!(f, "monolithic"),
         }
     }
 }
 
+/// Specifies whether to persist the processed circuits.
+#[derive(Debug, Clone, Copy)]
+pub enum CircuitPersistence {
+    /// Do not persist the processed circuits.
+    None,
+    /// Persist the processed circuits to disk.
+    Disk(TableLoadStrategy),
+}
+
+impl Default for CircuitPersistence {
+    fn default() -> Self {
+        CircuitPersistence::Disk(TableLoadStrategy::default())
+    }
+}
+
 /// Product of [`CircuitConfig`] and [`CircuitPersistence`].
-#[derive(Debug)]
-pub struct ProverStateConfig {
-    pub circuit_config: circuit::CircuitConfig,
+///
+/// Provides helper utilities for interacting with the prover state in
+/// accordance with the specified configuration and persistence strategy.
+#[derive(Default, Debug, Clone)]
+pub struct ProverStateManager {
+    pub circuit_config: CircuitConfig,
     pub persistence: CircuitPersistence,
 }
 
-/// Initializes the global prover state.
-pub fn set_prover_state_from_config(
-    ProverStateConfig {
-        circuit_config,
-        persistence,
-    }: ProverStateConfig,
-) -> Result<(), ProverState> {
-    info!("initializing prover state...");
-    let state = match persistence {
-        CircuitPersistence::None => {
-            info!("generating circuits...");
-            ProverState {
-                state: circuit_config.as_all_recursive_circuits(),
+impl ProverStateManager {
+    pub fn with_load_strategy(self, load_strategy: TableLoadStrategy) -> Self {
+        match self.persistence {
+            CircuitPersistence::None => self,
+            CircuitPersistence::Disk(_) => Self {
+                circuit_config: self.circuit_config,
+                persistence: CircuitPersistence::Disk(load_strategy),
+            },
+        }
+    }
+
+    /// Load the table circuits necessary to shrink the STARK proof.
+    ///
+    /// [`AllProof`] provides the necessary degree bits for each circuit via the
+    /// [`AllProof::degree_bits`] method.
+    /// Using this information, for each circuit, a tuple is returned,
+    /// containing:
+    /// 1. The loaded table circuit at the specified size.
+    /// 2. An offset indicating the position of the specified size within the
+    ///    configured range used when pre-generating the circuits.
+    fn load_table_circuits(
+        &self,
+        config: &StarkConfig,
+        all_proof: &AllProof<Field, Config, SIZE>,
+    ) -> anyhow::Result<[(RecursiveCircuitsForTableSize, u8); NUM_TABLES]> {
+        let degrees = all_proof.degree_bits(config);
+
+        /// Given a recursive circuit index (e.g., Arithmetic / 0), return a
+        /// tuple containing the loaded table at the specified size and
+        /// its offset relative to the configured range used to pre-process the
+        /// circuits.
+        macro_rules! circuit {
+            ($circuit_index:expr) => {
+                (
+                    RecursiveCircuitResource::get(&(
+                        $circuit_index.into(),
+                        degrees[$circuit_index],
+                    ))
+                    .map_err(|e| {
+                        let circuit: $crate::prover_state::circuit::Circuit = $circuit_index.into();
+                        let size = degrees[$circuit_index];
+                        anyhow::Error::from(e).context(format!(
+                            "Attempting to load circuit: {circuit:?} at size: {size}"
+                        ))
+                    })?,
+                    (degrees[$circuit_index] - self.circuit_config[$circuit_index].start) as u8,
+                )
+            };
+        }
+
+        Ok([
+            circuit!(0),
+            circuit!(1),
+            circuit!(2),
+            circuit!(3),
+            circuit!(4),
+            circuit!(5),
+            circuit!(6),
+        ])
+    }
+
+    /// Generate a transaction proof using the specified input, loading the
+    /// circuit tables as needed to shrink the individual STARK proofs, and
+    /// finally aggregating them to a final transaction proof.
+    fn txn_proof_on_demand(&self, input: TxnProofGenIR) -> anyhow::Result<GeneratedTxnProof> {
+        let config = StarkConfig::standard_fast_config();
+        let all_stark = AllStark::default();
+        let all_proof = prove(&all_stark, &config, input, &mut TimingTree::default(), None)?;
+
+        let table_circuits = self.load_table_circuits(&config, &all_proof)?;
+
+        let (intern, p_vals) =
+            p_state()
+                .state
+                .prove_root_after_initial_stark(all_proof, &table_circuits, None)?;
+
+        Ok(GeneratedTxnProof { intern, p_vals })
+    }
+
+    /// Generate a transaction proof using the specified input on the monolithic
+    /// circuit.
+    fn txn_proof_monolithic(&self, input: TxnProofGenIR) -> anyhow::Result<GeneratedTxnProof> {
+        let (intern, p_vals) = p_state().state.prove_root(
+            &AllStark::default(),
+            &StarkConfig::standard_fast_config(),
+            input,
+            &mut TimingTree::default(),
+            None,
+        )?;
+
+        Ok(GeneratedTxnProof { p_vals, intern })
+    }
+
+    /// Generate a transaction proof using the specified input.
+    ///
+    /// The specific implementation depends on the persistence strategy.
+    /// - If the persistence strategy is [`CircuitPersistence::None`] or
+    ///   [`CircuitPersistence::Disk`] with [`TableLoadStrategy::Monolithic`],
+    ///   the monolithic circuit is used.
+    /// - If the persistence strategy is [`CircuitPersistence::Disk`] with
+    ///   [`TableLoadStrategy::OnDemand`], the table circuits are loaded as
+    ///   needed.
+    pub fn generate_txn_proof(&self, input: TxnProofGenIR) -> anyhow::Result<GeneratedTxnProof> {
+        match self.persistence {
+            CircuitPersistence::None | CircuitPersistence::Disk(TableLoadStrategy::Monolithic) => {
+                info!("using monolithic circuit {:?}", self);
+                self.txn_proof_monolithic(input)
+            }
+            CircuitPersistence::Disk(TableLoadStrategy::OnDemand) => {
+                info!("using on demand circuit {:?}", self);
+                self.txn_proof_on_demand(input)
             }
         }
-        CircuitPersistence::Disk => {
-            info!("attempting to load preprocessed circuits from disk...");
-            let disk_state = persistence::prover_from_disk(&circuit_config);
-            match disk_state {
-                Some(circuits) => {
-                    info!("successfully loaded preprocessed circuits from disk");
-                    ProverState { state: circuits }
+    }
+
+    /// Initialize global prover state from the configuration.
+    pub fn initialize(&self) -> anyhow::Result<()> {
+        info!("initializing prover state...");
+
+        let state = match self.persistence {
+            CircuitPersistence::None => {
+                info!("generating circuits...");
+                ProverState {
+                    state: self.circuit_config.as_all_recursive_circuits(),
                 }
-                None => {
-                    info!("failed to load preprocessed circuits from disk. generating circuits...");
-                    let all_recursive_circuits = circuit_config.as_all_recursive_circuits();
-                    info!("saving preprocessed circuits to disk");
-                    persistence::to_disk(&all_recursive_circuits, &circuit_config);
-                    ProverState {
-                        state: all_recursive_circuits,
+            }
+            CircuitPersistence::Disk(strategy) => {
+                info!("attempting to load preprocessed circuits from disk...");
+
+                let disk_state = match strategy {
+                    TableLoadStrategy::OnDemand => BaseProverResource::get(&self.circuit_config),
+                    TableLoadStrategy::Monolithic => {
+                        MonolithicProverResource::get(&self.circuit_config)
+                    }
+                };
+
+                match disk_state {
+                    Ok(circuits) => {
+                        info!("successfully loaded preprocessed circuits from disk");
+                        ProverState { state: circuits }
+                    }
+                    Err(_) => {
+                        info!("failed to load preprocessed circuits from disk. generating circuits...");
+                        let all_recursive_circuits =
+                            self.circuit_config.as_all_recursive_circuits();
+                        info!("saving preprocessed circuits to disk");
+                        persistence::persist_all_to_disk(
+                            &all_recursive_circuits,
+                            &self.circuit_config,
+                        )?;
+                        ProverState {
+                            state: all_recursive_circuits,
+                        }
                     }
                 }
             }
-        }
-    };
+        };
 
-    P_STATE.set(state)
-}
+        P_STATE.set(state).map_err(|_| {
+            anyhow::Error::msg(
+                "prover state already set. check the program logic to ensure it is only set once",
+            )
+            .context("setting prover state")
+        })?;
 
-/// Loads a verifier state from disk or generate it.
-pub fn get_verifier_state_from_config(
-    ProverStateConfig {
-        circuit_config,
-        persistence,
-    }: ProverStateConfig,
-) -> VerifierState {
-    info!("initializing verifier state...");
-    match persistence {
-        CircuitPersistence::None => {
-            info!("generating circuit...");
-            let prover_state = circuit_config.as_all_recursive_circuits();
-            VerifierState {
-                state: prover_state.final_verifier_data(),
+        MANAGER.set(self.clone()).map_err(|_| {
+            anyhow::Error::msg(
+                "prover state manager already set. check the program logic to ensure it is only set once",
+            )
+            .context("setting prover state manager")
+        })?;
+
+        Ok(())
+    }
+
+    /// Loads a verifier state from disk or generate it.
+    pub fn verifier(&self) -> anyhow::Result<VerifierState> {
+        info!("initializing verifier state...");
+        match self.persistence {
+            CircuitPersistence::None => {
+                info!("generating circuit...");
+                let prover_state = self.circuit_config.as_all_recursive_circuits();
+                Ok(VerifierState {
+                    state: prover_state.final_verifier_data(),
+                })
             }
-        }
-        CircuitPersistence::Disk => {
-            info!("attempting to load preprocessed verifier circuit from disk...");
-            let disk_state = persistence::verifier_from_disk(&circuit_config);
-            match disk_state {
-                Some(state) => {
-                    info!("successfully loaded preprocessed verifier circuit from disk");
-                    VerifierState { state }
-                }
-                None => {
-                    info!(
-                        "failed to load preprocessed verifier circuit from disk. generating it..."
-                    );
-                    let prover_state = circuit_config.as_all_recursive_circuits();
+            CircuitPersistence::Disk(_) => {
+                info!("attempting to load preprocessed verifier circuit from disk...");
+                let disk_state = VerifierResource::get(&self.circuit_config);
 
-                    info!("saving preprocessed verifier circuit to disk");
-                    let state = prover_state.final_verifier_data();
-                    persistence::verifier_to_disk(&state, &circuit_config);
+                match disk_state {
+                    Ok(state) => {
+                        info!("successfully loaded preprocessed verifier circuit from disk");
+                        Ok(VerifierState { state })
+                    }
+                    Err(_) => {
+                        info!("failed to load preprocessed verifier circuit from disk. generating it...");
+                        let prover_state = self.circuit_config.as_all_recursive_circuits();
 
-                    VerifierState { state }
+                        info!("saving preprocessed verifier circuit to disk");
+                        let state = prover_state.final_verifier_data();
+                        VerifierResource::put(&self.circuit_config, &state)?;
+
+                        Ok(VerifierState { state })
+                    }
                 }
             }
         }

--- a/common/src/prover_state/persistence.rs
+++ b/common/src/prover_state/persistence.rs
@@ -1,126 +1,270 @@
 use std::{
+    fmt::{Debug, Display},
     fs::{self, OpenOptions},
     io::Write,
+    path::Path,
 };
 
-use plonky2::{
-    plonk::config::PoseidonGoldilocksConfig,
-    util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer},
+use plonky2::util::serialization::{
+    Buffer, DefaultGateSerializer, DefaultGeneratorSerializer, IoError,
 };
-use plonky_block_proof_gen::types::{AllRecursiveCircuits, VerifierData};
-use tracing::{info, warn};
+use proof_gen::types::{AllRecursiveCircuits, VerifierData};
+use thiserror::Error;
 
-use super::circuit::CircuitConfig;
+use super::{
+    circuit::{Circuit, CircuitConfig},
+    Config, RecursiveCircuitsForTableSize, SIZE,
+};
 
-type Config = PoseidonGoldilocksConfig;
-const SIZE: usize = 2;
-const PROVER_STATE_FILE_PREFIX: &str = "./prover_state";
-const VERIFIER_STATE_FILE_PREFIX: &str = "./verifier_state";
+const CIRCUITS_FOLDER: &str = "./circuits";
+const PROVER_STATE_FILE_PREFIX: &str = "prover_state";
+const VERIFIER_STATE_FILE_PREFIX: &str = "verifier_state";
 
-fn get_serializers() -> (DefaultGateSerializer, DefaultGeneratorSerializer<Config, 2>) {
+fn get_serializers() -> (
+    DefaultGateSerializer,
+    DefaultGeneratorSerializer<Config, SIZE>,
+) {
     let gate_serializer = DefaultGateSerializer;
-    let witness_serializer: DefaultGeneratorSerializer<Config, SIZE> = DefaultGeneratorSerializer {
-        _phantom: Default::default(),
-    };
+    let witness_serializer: DefaultGeneratorSerializer<Config, SIZE> =
+        DefaultGeneratorSerializer::default();
 
     (gate_serializer, witness_serializer)
 }
 
-#[inline]
-fn disk_path(circuit_config: &CircuitConfig, prefix: &str) -> String {
-    format!("{}_{}", prefix, circuit_config.get_configuration_digest())
+#[derive(Error, Debug)]
+pub(crate) enum DiskResourceError<E> {
+    #[error("Serialization error: {0}")]
+    Serialization(E),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
 }
 
-/// Loads [`AllRecursiveCircuits`] from disk.
-pub fn prover_from_disk(circuit_config: &CircuitConfig) -> Option<AllRecursiveCircuits> {
-    let path = disk_path(circuit_config, PROVER_STATE_FILE_PREFIX);
-    let bytes = fs::read(&path).ok()?;
-    info!("found prover state at {path}");
-    let (gate_serializer, witness_serializer) = get_serializers();
-    info!("deserializing prover state...");
-    let state =
-        AllRecursiveCircuits::from_bytes(&bytes, false, &gate_serializer, &witness_serializer);
+/// A trait for generic resources that may be written to and read from disk,
+/// each with their own serialization and deserialization logic.
+pub(crate) trait DiskResource {
+    /// The type of error that may arise while serializing or deserializing the
+    /// resource.
+    type Error: Debug + Display;
+    /// The type of resource being serialized, deserialized, and written to
+    /// disk.
+    type Resource;
+    /// The input type / configuration used to generate a unique path to the
+    /// resource on disk.
+    type PathConstrutor;
 
-    match state {
-        Ok(state) => Some(state),
-        Err(e) => {
-            warn!("failed to deserialize prover state, {e:?}");
-            None
+    /// Returns the path to the resource on disk.
+    fn path(p: &Self::PathConstrutor) -> impl AsRef<Path>;
+
+    /// Serializes the resource to bytes.
+    fn serialize(r: &Self::Resource) -> Result<Vec<u8>, DiskResourceError<Self::Error>>;
+
+    /// Deserializes the resource from bytes.
+    fn deserialize(bytes: &[u8]) -> Result<Self::Resource, DiskResourceError<Self::Error>>;
+
+    /// Reads the resource from disk and deserializes it.
+    fn get(p: &Self::PathConstrutor) -> Result<Self::Resource, DiskResourceError<Self::Error>> {
+        Self::deserialize(&fs::read(Self::path(p))?)
+    }
+
+    /// Writes the resource to disk after serializing it.
+    fn put(
+        p: &Self::PathConstrutor,
+        r: &Self::Resource,
+    ) -> Result<(), DiskResourceError<Self::Error>> {
+        // Create the base folder if non-existent.
+        if std::fs::metadata(CIRCUITS_FOLDER).is_err() {
+            std::fs::create_dir(CIRCUITS_FOLDER).map_err(|_| {
+                DiskResourceError::IoError::<Self::Error>(std::io::Error::other(
+                    "Could not create circuits folder",
+                ))
+            })?;
         }
+
+        Ok(OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(Self::path(p))?
+            .write_all(&Self::serialize(r)?)?)
     }
 }
 
-/// Loads [`VerifierData`] from disk.
-pub fn verifier_from_disk(circuit_config: &CircuitConfig) -> Option<VerifierData> {
-    let path = disk_path(circuit_config, VERIFIER_STATE_FILE_PREFIX);
-    let bytes = fs::read(&path).ok()?;
-    info!("found verifier state at {path}");
-    let (gate_serializer, _witness_serializer) = get_serializers();
-    info!("deserializing verifier state...");
-    let state = VerifierData::from_bytes(bytes, &gate_serializer);
+/// Pre-generated circuits containing just the three higher-level circuits.
+/// These are sufficient for generating aggregation proofs and block
+/// proofs, but not for transaction proofs.
+#[derive(Debug, Default)]
+pub(crate) struct BaseProverResource;
 
-    match state {
-        Ok(state) => Some(state),
-        Err(e) => {
-            warn!("failed to deserialize verifier state, {e:?}");
-            None
-        }
+impl DiskResource for BaseProverResource {
+    type Resource = AllRecursiveCircuits;
+    type Error = IoError;
+    type PathConstrutor = CircuitConfig;
+
+    fn path(p: &Self::PathConstrutor) -> String {
+        format!(
+            "{}/{}_base_{}",
+            CIRCUITS_FOLDER,
+            PROVER_STATE_FILE_PREFIX,
+            p.get_configuration_digest()
+        )
+    }
+
+    fn serialize(r: &Self::Resource) -> Result<Vec<u8>, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+
+        r
+            // Note we are using the `true` flag to write only the upper circuits.
+            // The individual circuit tables are written separately below.
+            .to_bytes(true, &gate_serializer, &witness_serializer)
+            .map_err(DiskResourceError::Serialization)
+    }
+
+    fn deserialize(bytes: &[u8]) -> Result<AllRecursiveCircuits, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+        AllRecursiveCircuits::from_bytes(bytes, true, &gate_serializer, &witness_serializer)
+            .map_err(DiskResourceError::Serialization)
     }
 }
 
-/// Writes the provided [`AllRecursiveCircuits`] to disk, along with the
-/// associated [`VerifierData`], in two distinct files.
-pub fn to_disk(circuits: &AllRecursiveCircuits, circuit_config: &CircuitConfig) {
-    prover_to_disk(circuits, circuit_config);
-    verifier_to_disk(&circuits.final_verifier_data(), circuit_config);
+/// Pre-generated circuits containing all circuits.
+#[derive(Debug, Default)]
+pub(crate) struct MonolithicProverResource;
+
+impl DiskResource for MonolithicProverResource {
+    type Resource = AllRecursiveCircuits;
+    type Error = IoError;
+    type PathConstrutor = CircuitConfig;
+
+    fn path(p: &Self::PathConstrutor) -> String {
+        format!(
+            "{}/{}_monolithic_{}",
+            CIRCUITS_FOLDER,
+            PROVER_STATE_FILE_PREFIX,
+            p.get_configuration_digest()
+        )
+    }
+
+    fn serialize(r: &Self::Resource) -> Result<Vec<u8>, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+
+        r
+            // Note we are using the `false` flag to write all circuits.
+            .to_bytes(false, &gate_serializer, &witness_serializer)
+            .map_err(DiskResourceError::Serialization)
+    }
+
+    fn deserialize(bytes: &[u8]) -> Result<AllRecursiveCircuits, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+        AllRecursiveCircuits::from_bytes(bytes, false, &gate_serializer, &witness_serializer)
+            .map_err(DiskResourceError::Serialization)
+    }
+}
+
+/// An individual circuit table with a specific size.
+#[derive(Debug, Default)]
+pub(crate) struct RecursiveCircuitResource;
+
+impl DiskResource for RecursiveCircuitResource {
+    type Resource = RecursiveCircuitsForTableSize;
+    type Error = IoError;
+    type PathConstrutor = (Circuit, usize);
+
+    fn path((circuit_type, size): &Self::PathConstrutor) -> String {
+        format!(
+            "{}/{}_{}_{}",
+            CIRCUITS_FOLDER,
+            PROVER_STATE_FILE_PREFIX,
+            circuit_type.as_short_str(),
+            size
+        )
+    }
+
+    fn serialize(r: &Self::Resource) -> Result<Vec<u8>, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+        let mut buf = Vec::new();
+
+        r.to_buffer(&mut buf, &gate_serializer, &witness_serializer)
+            .map_err(DiskResourceError::Serialization)?;
+
+        Ok(buf)
+    }
+
+    fn deserialize(
+        bytes: &[u8],
+    ) -> Result<RecursiveCircuitsForTableSize, DiskResourceError<Self::Error>> {
+        let (gate_serializer, witness_serializer) = get_serializers();
+        let mut buffer = Buffer::new(bytes);
+        RecursiveCircuitsForTableSize::from_buffer(
+            &mut buffer,
+            &gate_serializer,
+            &witness_serializer,
+        )
+        .map_err(DiskResourceError::Serialization)
+    }
+}
+
+/// An individual circuit table with a specific size.
+#[derive(Debug, Default)]
+pub(crate) struct VerifierResource;
+
+impl DiskResource for VerifierResource {
+    type Resource = VerifierData;
+    type Error = IoError;
+    type PathConstrutor = CircuitConfig;
+
+    fn path(p: &Self::PathConstrutor) -> String {
+        format!(
+            "{}/{}_{}",
+            CIRCUITS_FOLDER,
+            VERIFIER_STATE_FILE_PREFIX,
+            p.get_configuration_digest()
+        )
+    }
+
+    fn serialize(r: &Self::Resource) -> Result<Vec<u8>, DiskResourceError<Self::Error>> {
+        let (gate_serializer, _witness_serializer) = get_serializers();
+        r.to_bytes(&gate_serializer)
+            .map_err(DiskResourceError::Serialization)
+    }
+
+    fn deserialize(bytes: &[u8]) -> Result<Self::Resource, DiskResourceError<Self::Error>> {
+        let (gate_serializer, _) = get_serializers();
+        VerifierData::from_bytes(bytes.to_vec(), &gate_serializer)
+            .map_err(DiskResourceError::Serialization)
+    }
+}
+
+/// Writes the provided [`AllRecursiveCircuits`] to disk with all
+/// configurations, along with the associated [`VerifierData`].
+pub fn persist_all_to_disk(
+    circuits: &AllRecursiveCircuits,
+    circuit_config: &CircuitConfig,
+) -> anyhow::Result<()> {
+    prover_to_disk(circuit_config, circuits)?;
+    VerifierResource::put(circuit_config, &circuits.final_verifier_data())?;
+
+    Ok(())
 }
 
 /// Writes the provided [`AllRecursiveCircuits`] to disk.
-fn prover_to_disk(circuits: &AllRecursiveCircuits, circuit_config: &CircuitConfig) {
-    let (gate_serializer, witness_serializer) = get_serializers();
+///
+/// In particular, we cover both the monolothic and base prover states, as well
+/// as the individual circuit tables.
+fn prover_to_disk(
+    circuit_config: &CircuitConfig,
+    circuits: &AllRecursiveCircuits,
+) -> Result<(), DiskResourceError<IoError>> {
+    BaseProverResource::put(circuit_config, circuits)?;
+    MonolithicProverResource::put(circuit_config, circuits)?;
 
-    // Write prover state to disk
-    if let Err(e) = circuits
-        .to_bytes(false, &gate_serializer, &witness_serializer)
-        .map(|bytes| {
-            write_bytes_to_file(&bytes, disk_path(circuit_config, PROVER_STATE_FILE_PREFIX))
-        })
-    {
-        warn!("failed to create prover state file, {e:?}");
-    };
-}
-
-/// Writes the provided [`VerifierData`] to disk.
-pub fn verifier_to_disk(circuit: &VerifierData, circuit_config: &CircuitConfig) {
-    let (gate_serializer, _witness_serializer) = get_serializers();
-
-    // Write verifier state to disk
-    if let Err(e) = circuit.to_bytes(&gate_serializer).map(|bytes| {
-        write_bytes_to_file(
-            &bytes,
-            disk_path(circuit_config, VERIFIER_STATE_FILE_PREFIX),
-        )
-    }) {
-        warn!("failed to create verifier state file, {e:?}");
-    };
-}
-
-fn write_bytes_to_file(bytes: &[u8], path: String) {
-    let file = OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(path);
-
-    let mut file = match file {
-        Ok(file) => file,
-        Err(e) => {
-            warn!("failed to create circuits file, {e:?}");
-            return;
+    // Write individual circuit tables to disk, by circuit type and size. This
+    // allows us to load only the necessary tables when needed.
+    for (circuit_type, tables) in circuits.by_table.iter().enumerate() {
+        let circuit_type: Circuit = circuit_type.into();
+        for (size, table) in tables.by_stark_size.iter() {
+            RecursiveCircuitResource::put(&(circuit_type, *size), table)?;
         }
-    };
-
-    if let Err(e) = file.write_all(bytes) {
-        warn!("failed to write circuits file, {e:?}");
     }
+
+    Ok(())
 }

--- a/leader/Cargo.toml
+++ b/leader/Cargo.toml
@@ -17,8 +17,7 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 dotenvy = { workspace = true }
 tokio = { workspace = true }
-plonky2_evm = { workspace = true }
-plonky_block_proof_gen = { workspace = true }
+proof_gen = { workspace = true }
 serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }
 ethereum-types = { workspace = true }
@@ -29,3 +28,7 @@ ops = { path = "../ops" }
 prover = { path = "../prover" }
 rpc = { path = "../rpc" }
 common = { path = "../common" }
+
+[features]
+default = []
+test_only = ["ops/test_only", "prover/test_only"]

--- a/leader/src/http.rs
+++ b/leader/src/http.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use axum::{http::StatusCode, routing::post, Json, Router};
 use ethereum_types::U256;
 use paladin::runtime::Runtime;
-use plonky_block_proof_gen::{proof_types::GeneratedBlockProof, types::PlonkyProofIntern};
+use proof_gen::{proof_types::GeneratedBlockProof, types::PlonkyProofIntern};
 use prover::ProverInput;
 use serde::{Deserialize, Serialize};
 use serde_json::to_writer;

--- a/leader/src/jerigon.rs
+++ b/leader/src/jerigon.rs
@@ -6,8 +6,7 @@ use std::{
 
 use anyhow::Result;
 use paladin::runtime::Runtime;
-use plonky2_evm::proof::PublicValues;
-use plonky_block_proof_gen::types::PlonkyProofIntern;
+use proof_gen::types::PlonkyProofIntern;
 
 /// The main function for the jerigon mode.
 pub(crate) async fn jerigon_main(
@@ -26,14 +25,6 @@ pub(crate) async fn jerigon_main(
     .await?;
 
     let proof = prover_input.prove(&runtime, previous).await;
-
-    let recovered_pub_vals =
-        PublicValues::from_public_inputs(&proof.as_ref().unwrap().intern.public_inputs);
-
-    println!(
-        "Public vals of block {}: {:#?}",
-        block_number, recovered_pub_vals
-    );
 
     runtime.close().await?;
 

--- a/leader/src/main.rs
+++ b/leader/src/main.rs
@@ -3,12 +3,11 @@ use std::{fs::File, path::PathBuf};
 use anyhow::Result;
 use clap::Parser;
 use cli::Command;
-use common::prover_state::set_prover_state_from_config;
+use common::prover_state::TableLoadStrategy;
 use dotenvy::dotenv;
 use ops::register;
 use paladin::runtime::Runtime;
-use plonky_block_proof_gen::types::PlonkyProofIntern;
-use tracing::warn;
+use proof_gen::types::PlonkyProofIntern;
 
 mod cli;
 mod http;
@@ -37,11 +36,12 @@ async fn main() -> Result<()> {
     if let paladin::config::Runtime::InMemory = args.paladin.runtime {
         // If running in emulation mode, we'll need to initialize the prover
         // state here.
-        if set_prover_state_from_config(args.prover_state_config.into()).is_err() {
-            warn!(
-                "prover state already set. check the program logic to ensure it is only set once"
-            );
-        }
+        args.prover_state_config
+            .into_prover_state_manager()
+            // Use the monolithic load strategy for the prover state when running in
+            // emulation mode.
+            .with_load_strategy(TableLoadStrategy::Monolithic)
+            .initialize()?;
     }
 
     let runtime = Runtime::from_config(&args.paladin, register()).await?;

--- a/leader/src/stdio.rs
+++ b/leader/src/stdio.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 
 use anyhow::Result;
 use paladin::runtime::Runtime;
-use plonky_block_proof_gen::types::PlonkyProofIntern;
+use proof_gen::types::PlonkyProofIntern;
 use prover::ProverInput;
 
 /// The main function for the stdio mode.

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -11,7 +11,12 @@ categories.workspace = true
 [dependencies]
 paladin-core = { workspace = true }
 serde = { workspace = true }
-plonky_block_proof_gen = { workspace = true }
-protocol_decoder = { workspace = true }
+evm_arithmetization = { workspace = true, optional = true}
+proof_gen = { workspace = true }
+trace_decoder = { workspace = true }
 
 common = { path = "../common" }
+
+[features]
+default = []
+test_only = ["evm_arithmetization"]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -10,12 +10,17 @@ categories.workspace = true
 
 [dependencies]
 serde = { workspace = true }
-plonky_block_proof_gen = { workspace = true }
-protocol_decoder = { workspace = true }
+proof_gen = { workspace = true }
+trace_decoder = { workspace = true }
 tracing = { workspace = true }
 paladin-core = { workspace = true }
 ethereum-types = { workspace = true }
 anyhow = { workspace = true }
+futures = { workspace = true }
 
 # Local dependencies
 ops = { path = "../ops" }
+
+[features]
+default = ["test_only"]
+test_only = ["ops/test_only"]

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -1,20 +1,18 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use ethereum_types::U256;
-use ops::{AggProof, BlockProof, TxProof};
+use futures::stream::TryStreamExt;
+use ops::TxProof;
 use paladin::{
-    directive::{Directive, IndexedStream, Literal},
+    directive::{Directive, IndexedStream},
     runtime::Runtime,
 };
-use plonky_block_proof_gen::{
-    proof_types::{AggregatableProof, GeneratedBlockProof},
-    types::PlonkyProofIntern,
-};
-use protocol_decoder::{
+use proof_gen::{proof_types::GeneratedBlockProof, types::PlonkyProofIntern};
+use serde::{Deserialize, Serialize};
+use trace_decoder::{
     processed_block_trace::ProcessingMeta,
     trace_protocol::BlockTrace,
     types::{CodeHash, OtherBlockData},
 };
-use serde::{Deserialize, Serialize};
 use tracing::info;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -31,6 +29,7 @@ impl ProverInput {
         self.other_data.b_data.b_meta.block_number
     }
 
+    #[cfg(not(feature = "test_only"))]
     pub async fn prove(
         self,
         runtime: &Runtime,
@@ -47,25 +46,56 @@ impl ProverInput {
 
         let agg_proof = IndexedStream::from(txs)
             .map(&TxProof)
-            .fold(&AggProof)
+            .fold(&ops::AggProof)
             .run(runtime)
             .await?;
 
-        if let AggregatableProof::Agg(proof) = agg_proof {
+        if let proof_gen::proof_types::AggregatableProof::Agg(proof) = agg_proof {
             let prev = previous.map(|p| GeneratedBlockProof {
                 b_height: block_number.as_u64() - 1,
                 intern: p,
             });
 
-            let block_proof = Literal(proof)
-                .map(&BlockProof { prev })
+            let block_proof = paladin::Literal(proof)
+                .map(&ops::BlockProof { prev })
                 .run(runtime)
                 .await?;
 
             info!("Successfully proved block {block_number}");
             Ok(block_proof.0)
         } else {
-            bail!("AggProof is is not GeneratedAggProof")
+            anyhow::bail!("AggProof is is not GeneratedAggProof")
         }
+    }
+
+    #[cfg(feature = "test_only")]
+    pub async fn prove(
+        self,
+        runtime: &Runtime,
+        _previous: Option<PlonkyProofIntern>,
+    ) -> Result<GeneratedBlockProof> {
+        let block_number = self.get_block_number();
+        info!("Testing witness generation for block {block_number}.");
+
+        let other_data = self.other_data;
+        let txs = self.block_trace.into_txn_proof_gen_ir(
+            &ProcessingMeta::new(resolve_code_hash_fn),
+            other_data.clone(),
+        )?;
+
+        IndexedStream::from(txs)
+            .map(&TxProof)
+            .run(runtime)
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        info!("Successfully generated witness for block {block_number}.");
+
+        // Dummy proof to match expected output type.
+        Ok(GeneratedBlockProof {
+            b_height: block_number.as_u64(),
+            intern: proof_gen::proof_gen::dummy_proof()?,
+        })
     }
 }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -14,14 +14,17 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
-protocol_decoder = { workspace = true }
+trace_decoder = { workspace = true }
 serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }
 clap = { workspace = true }
 ethereum-types = { workspace = true }
-plonky2_evm = { workspace = true }
+evm_arithmetization = { workspace = true }
 thiserror = { workspace = true }
+futures = { workspace = true }
 
+hex = "0.4.3"
+hex-literal = "0.4.1"
 reqwest = { version = "0.11.22", default-features = false, features = [
   "json",
   "rustls-tls",
@@ -30,7 +33,4 @@ reqwest = { version = "0.11.22", default-features = false, features = [
 
 # Local dependencies
 common = { path = "../common" }
-futures = "0.3.29"
-hex = "0.4.3"
-hex-literal = "0.4.1"
 prover = { path = "../prover" }

--- a/tools/debug_block.sh
+++ b/tools/debug_block.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Args:
+# 1 --> Block idx
+# 2 --> Rpc endpoint:port (eg. http://35.246.1.96:8545)
+
+export RUST_BACKTRACE=1
+export RUST_LOG=plonky2=info,mpt_trie=info,evm_arithmetization=info,trace_decoder=info
+
+# Speciying smallest ranges, as we won't need them anyway.
+export ARITHMETIC_CIRCUIT_SIZE="16..17"
+export BYTE_PACKING_CIRCUIT_SIZE="9..10"
+export CPU_CIRCUIT_SIZE="12..13"
+export KECCAK_CIRCUIT_SIZE="14..15"
+export KECCAK_SPONGE_CIRCUIT_SIZE="9..10"
+export LOGIC_CIRCUIT_SIZE="12..13"
+export MEMORY_CIRCUIT_SIZE="17..18"
+
+OUTPUT_DIR="debug"
+OUT_DUMMY_PROOF_PATH="${OUTPUT_DIR}/b${1}.zkproof"
+OUT_LOG_PATH="${OUTPUT_DIR}/b${1}.log"
+
+echo "Testing block ${1}..."
+mkdir -p $OUTPUT_DIR
+
+cargo r --release --features test_only --bin leader -- --runtime in-memory jerigon --rpc-url "$2" --block-number "$1" --checkpoint-block-number "$(($1-1))" --proof-output-path $OUT_DUMMY_PROOF_PATH > $OUT_LOG_PATH 2>&1
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    # Some error occured.
+    echo "Witness generation for block ${1} errored. See ${OUT_LOG_PATH} for more details."
+else
+    echo "Witness generation for block ${1} succeeded."
+    # Remove the log / dummy proof on success.
+    rm $OUT_DUMMY_PROOF_PATH
+    rm $OUT_LOG_PATH
+fi
+

--- a/tools/prove_blocks.sh
+++ b/tools/prove_blocks.sh
@@ -9,7 +9,7 @@
 export RUST_BACKTRACE=1
 export RUST_LOG=plonky2=info,plonky2_evm=info,protocol_decoder=info
 
-export ARTITHMETIC_CIRCUIT_SIZE="16..21"
+export ARITHMETIC_CIRCUIT_SIZE="16..21"
 export BYTE_PACKING_CIRCUIT_SIZE="9..21"
 export CPU_CIRCUIT_SIZE="12..23"
 export KECCAK_CIRCUIT_SIZE="14..18"
@@ -22,7 +22,7 @@ ALWAYS_WRITE_LOGS=0 # Change this to `1` if you always want logs to be written.
 
 TOT_BLOCKS=$(($2-$1+1))
 
-mkdir -p proofs/
+mkdir -p $PROOF_OUTPUT_DIR
 
 for ((i=$1; i<=$2; i++))
 do

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -12,7 +12,7 @@ dotenvy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }
-plonky_block_proof_gen = { workspace = true }
+proof_gen = { workspace = true }
 
 # Local dependencies
 common = { path = "../common" }

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -2,8 +2,7 @@ use std::fs::File;
 
 use anyhow::Result;
 use clap::Parser;
-use common::prover_state::get_verifier_state_from_config;
-use plonky_block_proof_gen::types::PlonkyProofIntern;
+use proof_gen::types::PlonkyProofIntern;
 use serde_json::Deserializer;
 
 mod cli;
@@ -17,9 +16,12 @@ fn main() -> Result<()> {
     let des = &mut Deserializer::from_reader(&file);
     let input: PlonkyProofIntern = serde_path_to_error::deserialize(des)?;
 
-    let verifier_state = get_verifier_state_from_config(args.prover_state_config.into());
+    let verifer = args
+        .prover_state_config
+        .into_prover_state_manager()
+        .verifier()?;
 
-    verifier_state.verify(&input)?;
+    verifer.verify(&input)?;
 
     Ok(())
 }

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
 use clap::Parser;
-use common::prover_state::{cli::CliProverStateConfig, set_prover_state_from_config};
+use common::prover_state::cli::CliProverStateConfig;
 use dotenvy::dotenv;
 use ops::register;
 use paladin::runtime::WorkerRuntime;
-use tracing::warn;
 
 mod init;
 
@@ -22,9 +21,9 @@ async fn main() -> Result<()> {
     init::tracing();
     let args = Cli::parse();
 
-    if set_prover_state_from_config(args.prover_state_config.into()).is_err() {
-        warn!("prover state already set. check the program logic to ensure it is only set once");
-    }
+    args.prover_state_config
+        .into_prover_state_manager()
+        .initialize()?;
 
     let runtime = WorkerRuntime::from_config(&args.paladin, register()).await?;
     runtime.main_loop().await?;


### PR DESCRIPTION
# Description

Brings latest changes from upstream. Includes:

- switch to new `zk_evm` monorepo
- several fixes on the backend side
- circuit-loading on-demand (for lighter memory requirements post offline preprocessing)